### PR TITLE
Run Activate only when inside window

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -522,7 +522,10 @@ namespace LNAB
             this.host = strArrays1[0];
             port = Convert.ToInt16(strArrays1[1]);
             this.app = strArrays[3];
-            this.Activate();
+            if (inside)
+            {
+                this.Activate();
+            }
             Uri uri = new Uri(this.appName);
 
             // Service Host Started
@@ -2257,6 +2260,7 @@ namespace LNAB
             if (inside)
             {
                 // just entered active window
+                this.Activate();
                 if (this.searchOpen()) start();
             }
             else


### PR DESCRIPTION
## Summary
- Activate only when start time is within scheduled window
- Ensure boundary timer activates service before starting searches and inactivates on exit

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c096cf71488330be97a8b306fed7da